### PR TITLE
chore: Integrate SonarCloud for code analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,25 @@
-name: CI
+name: CI & SonarCloud Analysis
 
 on:
+  push:
+    branches:
+      - master # Run on merges to master to update SonarCloud dashboard
   pull_request:
     branches:
-      - '**'
+      - master # Run on pull requests targeting master
 
 jobs:
-  build-and-test:
+  build-and-analyze:
+    name: Build, Test, and Analyze
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # This is required for SonarCloud to perform a full analysis.
+          fetch-depth: 0
 
-      - name: Setup Node
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -21,11 +28,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Format check
+      - name: Run Format Check
         run: npm run format:check
 
-      - name: Lint
+      - name: Run Linters
         run: npm run lint
 
-      - name: Unit tests with coverage
+      - name: Run Unit Tests with Coverage
         run: npm run test:coverage
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+# SonarCloud project configuration
+
+# --- Required configuration ---
+sonar.projectKey=DarpanBeri_DarpanBeri.github.io
+sonar.organization=darpanberi
+
+# --- Project settings ---
+# Tells SonarCloud to scan all files in the current directory.
+sonar.sources=.
+
+# This is the most important line for test coverage. It tells SonarCloud where to find the
+# coverage report that Jest creates, so it can track our test coverage percentage.
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# This tells SonarCloud to ignore folders we don't want to analyze,
+# such as third-party code and build outputs.
+sonar.exclusions=**/node_modules/**,**/vendor/**,**/coverage/**


### PR DESCRIPTION
This PR integrates SonarCloud with the repository.

Changes:
- Add sonar-project.properties with project key, organization, sources, coverage report path (coverage/lcov.info), and exclusions.
- Replace CI workflow with a SonarCloud-enabled pipeline that runs format check, linters, unit tests with coverage, and SonarCloud scan on pushes and PRs to master.

Notes:
- SONAR_TOKEN must be configured in repository secrets for the SonarCloud action. GITHUB_TOKEN is provided automatically by GitHub Actions.
- Jest coverage is already configured to output lcov via npm run test:coverage.