### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build-and-analyze:
     name: Build, Test, and Analyze
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/DarpanBeri/DarpanBeri.github.io/security/code-scanning/4](https://github.com/DarpanBeri/DarpanBeri.github.io/security/code-scanning/4)

The best fix is to explicitly add a `permissions` block with the minimal required level (`contents: read`) for the `build-and-analyze` job in `.github/workflows/ci.yml`. This should be placed directly under the job entry to ensure that only the required permissions are provided to the `GITHUB_TOKEN` for that job. The change consists of inserting:

```yaml
permissions:
  contents: read
```

between lines 13 and 14, beneath `name: Build, Test, and Analyze:` and above `runs-on:`. No other code or external dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
