### PR TITLE
feat(csp): add hardened Content-Security-Policy via <meta>

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -544,6 +544,12 @@ ul li {
   border-radius: 4px;
 }
 
+/* Contact form status box: hidden until JS reveals it via el.style.display.
+   Kept in CSS (not an inline style attr) so a strict CSP style-src needs no 'unsafe-inline'. */
+#form-status {
+  display: none;
+}
+
 .alert-success {
   color: #3c763d;
   background-color: #dff0d8;

--- a/index.html
+++ b/index.html
@@ -2,6 +2,10 @@
 <html lang="en" data-theme="light">
   <head>
     <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com; font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; img-src 'self'; connect-src 'self' https://formspree.io; form-action 'self' https://formspree.io; base-uri 'self'; object-src 'none'; frame-src 'none'; upgrade-insecure-requests"
+    />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
       integrity="sha512-TyUaMbYrKFZfQfp+9nQGOEt+vGu4nKzLk0KaV3nFifL3K8n7lzb8DayTzLOK0pNyzxGJzGRSw78e8xqJhURJ3Q=="
       crossorigin="anonymous"
     />
-    <link href="assets/css/main.css?v=1786930002" rel="stylesheet" />
+    <link href="assets/css/main.css?v=1786944935" rel="stylesheet" />
   </head>
 
   <body>
@@ -640,7 +640,7 @@
               collaborations.
             </p>
             <!-- Add a single form status element -->
-            <div id="form-status" class="alert" style="display: none"></div>
+            <div id="form-status" class="alert"></div>
 
             <!-- Updated minimalist contact form -->
             <form id="contactForm" action="https://formspree.io/f/xkgrwpbr" method="POST">

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -33,6 +33,14 @@ test.describe('Portfolio E2E', () => {
     await expect(page.locator('#index')).toBeVisible();
   });
 
+  test('form-status starts hidden via CSS, without an inline style attribute', async ({ page }) => {
+    const status = page.locator('#form-status');
+    // A strict style-src blocks inline `style="..."` attributes, so there must be none.
+    expect(await status.getAttribute('style')).toBeNull();
+    // It must still be hidden on load (now enforced by a CSS rule, not the attribute).
+    await expect(status).toBeHidden();
+  });
+
   test('Section Navigation: Work -> Back to Home', async ({ page }) => {
     // Navigate to Work
     await page.locator('#work').click();

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -379,8 +379,15 @@ test.describe('Issue #19: debug scaffolding removed', () => {
     await expect(page.locator('#index')).toBeVisible();
   });
 
-  test('no SAFE-MODE Content-Security-Policy meta is present', async ({ page }) => {
-    await expect(page.locator('meta[http-equiv="Content-Security-Policy"]')).toHaveCount(0);
+  test('an intentional CSP meta is present (replaces the removed #19 SAFE-MODE policy)', async ({
+    page,
+  }) => {
+    const meta = page.locator('meta[http-equiv="Content-Security-Policy"]');
+    await expect(meta).toHaveCount(1);
+    const content = (await meta.getAttribute('content')) || '';
+    // The #19 bug was a script-src that failed to allow the app's own origin.
+    // The replacement policy must always permit same-origin scripts.
+    expect(content).toMatch(/script-src 'self'/);
   });
 
   test('Google Analytics is not loaded', async ({ page }) => {
@@ -501,5 +508,68 @@ test.describe('SEO & head assets', () => {
   test('sitemap.xml lists the canonical URL', () => {
     const sitemap = fs.readFileSync(path.join(repoRoot, 'sitemap.xml'), 'utf8');
     expect(sitemap).toContain('<loc>https://darpanberi.github.io/</loc>');
+  });
+});
+
+test.describe('Content-Security-Policy', () => {
+  test('policy is hardened and correctly scoped to real dependencies', async ({ page }) => {
+    await page.goto(fileUrl, { waitUntil: 'load' });
+    const meta = page.locator('meta[http-equiv="Content-Security-Policy"]');
+    await expect(meta).toHaveCount(1);
+    const content = (await meta.getAttribute('content')) || '';
+
+    // No inline/eval escape hatches anywhere in the policy.
+    expect(content).not.toContain('unsafe-inline');
+    expect(content).not.toContain('unsafe-eval');
+
+    // Scripts: same-origin only (script.js). This is the exact #19 fix.
+    expect(content).toMatch(/script-src 'self'/);
+
+    // Styles: self + the two CSS origins actually loaded (animate.css/Font Awesome, Google Fonts).
+    expect(content).toMatch(/style-src[^;]*'self'/);
+    expect(content).toMatch(/style-src[^;]*https:\/\/cdnjs\.cloudflare\.com/);
+    expect(content).toMatch(/style-src[^;]*https:\/\/fonts\.googleapis\.com/);
+
+    // Fonts: Font Awesome webfonts (cdnjs) + Google woff2 (gstatic).
+    expect(content).toMatch(/font-src[^;]*https:\/\/cdnjs\.cloudflare\.com/);
+    expect(content).toMatch(/font-src[^;]*https:\/\/fonts\.gstatic\.com/);
+
+    // Contact form endpoint must be reachable via fetch and native submit.
+    expect(content).toMatch(/connect-src[^;]*https:\/\/formspree\.io/);
+    expect(content).toMatch(/form-action[^;]*https:\/\/formspree\.io/);
+
+    // Lockdown backstops.
+    expect(content).toMatch(/object-src 'none'/);
+    expect(content).toMatch(/base-uri 'self'/);
+  });
+
+  test('no CSP violations fire during a full interaction pass', async ({ page }) => {
+    // NOTE: the e2e suite runs via file://, where browsers enforce CSP unreliably,
+    // so this is a best-effort safety net — the authoritative runtime check is the
+    // served-origin chrome-devtools pass in Task 3. Listeners must attach before goto.
+    const violations = [];
+    page.on('console', (msg) => {
+      const t = msg.text();
+      if (/Content Security Policy|Refused to (load|apply|execute|connect|create)/i.test(t)) {
+        violations.push(t);
+      }
+    });
+    page.on('pageerror', (err) => {
+      if (/Content Security Policy/i.test(err.message)) violations.push(err.message);
+    });
+
+    await page.goto(fileUrl, { waitUntil: 'load' });
+
+    // Exercise fade()/element.style writes + CDN-backed assets.
+    await page.locator('#work').click();
+    await expect(page.locator('#work_scroll')).toBeVisible();
+    await page.locator('#owl-demo .carousel__dot').nth(1).click();
+    await page.locator('.go-back-home').click();
+    await expect(page.locator('#index')).toBeVisible();
+    await page.locator('.theme-toggle').click();
+    await page.locator('#contact').click();
+    await expect(page.locator('#contact_scroll')).toBeVisible();
+
+    expect(violations).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Re-introduces a **Content-Security-Policy** to the site (it shipped with none since GA/CSP were removed in #19). GitHub Pages cannot set HTTP response headers, so the policy is delivered via a single `<meta http-equiv="Content-Security-Policy">` placed at the top of `<head>` (before all resource-loading tags, so every load is governed).

The policy is a strict allowlist with **no `'unsafe-inline'`/`'unsafe-eval'` anywhere**, and every origin traces to a real dependency:

```
default-src 'self'; script-src 'self';
style-src 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com;
font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com;
img-src 'self'; connect-src 'self' https://formspree.io;
form-action 'self' https://formspree.io; base-uri 'self';
object-src 'none'; frame-src 'none'; upgrade-insecure-requests
```

**Enabler:** the single inline `style="display:none"` on `#form-status` was moved to a CSS rule (`#form-status { display: none; }`) so `style-src` needs no `'unsafe-inline'`. No JS logic changed — the `fade()` helper toggles visibility via `el.style.*` **property setters**, which browsers do **not** gate on `style-src` (only `cssText`/`setAttribute("style")`/`<style>`/HTML `style=` attrs are gated).

**Regression gate:** new `Content-Security-Policy` Playwright block — a directive assertion (fails if a directive is dropped or an escape hatch is reintroduced) plus a console-violation sentinel. The obsolete #19 test that asserted *zero* CSP metas was updated to assert the intentional one is present.

**Accepted limitation:** `frame-ancestors`/`report-uri`/`sandbox`/Report-Only are header-only and unavailable via `<meta>`, so clickjacking protection isn't achievable on GitHub Pages static hosting.

## Checklist

- [x] Uses personal account for commits (per-repo config)
- [x] No inline JavaScript or unsafe patterns
- [x] External links with target="_blank" include rel="noopener noreferrer"
- [x] Lint/format pass locally (`npm run lint` / `npm run format:check`)
- [x] Unit tests updated/added (`npm run test`)
- [x] Coverage maintained or improved (`npm run test:coverage`)
- [x] E2E tests updated/added if UI behavior changed
- [x] A11y/HTML/link checks pass locally (when applicable)
- [x] Documentation updated (README) as needed — n/a (agent docs are git-ignored)

## Test plan

- `npm run check-all` → exit 0 (format:check, lint, **47** unit, **36** e2e, HTML 0 errors, 25 links)
- `npm run check:a11y` → **0 violations**
- Authoritative runtime check on the served origin (`npm run serve` + chrome-devtools): every governed resource loads 200 under the enforced policy (same-origin JS/CSS/images/favicon, both CDN stylesheets, both font origins); a negative-control `fetch` to a disallowed origin is blocked by `connect-src` while `formspree.io` is allowed; screenshot confirms the page renders (no `opacity:0` regression).

## Related issues

n/a